### PR TITLE
Show exec-time errors in ace

### DIFF
--- a/lib/directive/display.js
+++ b/lib/directive/display.js
@@ -2,10 +2,11 @@ var app = require('../app');
 
 app.directive('display', function ($window) {
     return {
+        require     : '^workspace',
         restrict    : 'E',
         templateUrl : '/directive/display.html',
         scope       : { ngSource: '=' },
-        link        : function (scope, element, attrs) {
+        link        : function (scope, element, attrs, workspaceCtl) {
             scope.canvas = element.find('canvas')[0];
             scope.ctx = scope.canvas.getContext('2d');
 
@@ -20,7 +21,17 @@ app.directive('display', function ($window) {
                 var language = require('../language/index'),
                     settings = scope;
 
-                language.run(scope.ngSource, settings);
+                err = language.run(scope.ngSource, settings);
+                if (err) {
+                    workspaceCtl.setCustomAnnotations([{
+                        row: err.loc[0],
+                        column: err.loc[1],
+                        text: err.message,
+                        type: "error"
+                    }]);
+                } else {
+                    workspaceCtl.clearCustomAnnotations();
+                }
             };
 
             scope.resize = function () {

--- a/lib/directive/editor.js
+++ b/lib/directive/editor.js
@@ -14,16 +14,19 @@ var dont = false,
 
 app.directive('editor', function () {
     return {
+        require     : '^workspace',
         restrict    : 'E',
         templateUrl : '/directive/editor.html',
         scope       : { ngModel: '=', editable: '=', autoSelect: '=', ngChange: '&', startAtLine: '=' },
-        link        : function (scope, element, attrs) {
+        link        : function (scope, element, attrs, workspaceCtl) {
             var options = defaults;
 
             scope.ngModel = scope.ngModel || element[0].innerHTML;
 
             var engine = window.ace.edit(element[0]),
                 session = engine.getSession();
+
+            workspaceCtl.setEditorSession(session);
 
             engine.setTheme(options.theme);
             session.setUseWrapMode(options.wrapMode);

--- a/lib/directive/workspace.js
+++ b/lib/directive/workspace.js
@@ -1,0 +1,50 @@
+var app = require('../app');
+
+/*
+ * This directive is there to facilitate the communication between the
+ * editor and display directives through an API without using the $rootScope.
+ */
+app.directive('workspace', function ($window) {
+    return {
+        restrict: 'A',
+        controller: function ($scope, $element, $attrs) {
+            $scope.editor_session = null;
+            $scope.custom_annotations = [];
+
+            this.setCustomAnnotations = function (annotations) {
+                $scope.custom_annotations = annotations;
+                if ($scope.editor_session) {
+                    $scope.editor_session.setAnnotations(annotations);
+                }
+            };
+
+            this.clearCustomAnnotations = function () {
+                this.setCustomAnnotations([]);
+            };
+
+            this.setEditorSession = function (session) {
+                $scope.editor_session = session;
+
+                /* Watch annotation changes and re-add our custom ones
+                 * in case the ace background worker clears them.
+                 */
+                session.on('changeAnnotation', function () {
+                    var current = session.getAnnotations();
+                    var toBeAdded = [];
+                    $scope.custom_annotations.forEach(function (cust_annot) {
+                        var needsAdding;
+                        needsAdding = current.every(function (curr_annot) {
+                            return cust_annot.text != curr_annot.text;
+                        });
+
+                        if (needsAdding)
+                            toBeAdded.push(cust_annot);
+                    });
+                    if (toBeAdded.length > 0)
+                        session.setAnnotations(current.concat(toBeAdded));
+                });
+            };
+        }
+    };
+});
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,8 @@ require('./controller/export');
 require('./controller/loadDialog');
 
 // Directives
+
+require('./directive/workspace');
 require('./directive/editor');
 require('./directive/display');
 

--- a/lib/language/index.js
+++ b/lib/language/index.js
@@ -45,7 +45,7 @@ function run(code, settings) {
     session.steps = [];
 
     try {
-        compiled = coffee.compile(code || '');
+        compiled = coffee.compile(code || '', {sourceMap: true});
     } catch (err) {
         if (config.DEBUG_LEVEL > 0) {
             console.warn('[ Compile error ] ' +  err);
@@ -54,15 +54,36 @@ function run(code, settings) {
     }
 
     try {
-        eval(compiled);
+        eval(compiled.js);
     } catch (err) {
+        var js_loc = get_error_location(err),
+            coffee_loc = compiled.sourceMap.sourceLocation(js_loc);
+
         if (config.DEBUG_LEVEL > 0) {
             console.warn('[ API error ] ' + err);
         }
-        return;
+        return {message: err.message, loc: coffee_loc};
     }
 
     utils.drawCursor(session.pos);
+}
+
+function get_error_location(err) {
+    var trace,
+        trace_top;
+
+    trace = err.stack.split('\n').map(function (line) {
+        return line.match(/\s+at Object\.eval \((.+):(\d+):(\d+)\)/);
+    }).filter(function (match) {
+        return match != null;
+    });
+
+    if (trace.length > 0) {
+        trace_top = trace[0];
+        return [parseInt(trace_top[2])-1, parseInt(trace_top[3])-1];
+    } else {
+        return [0, 0];
+    }
 }
 
 function strip(code) {

--- a/views/level.jade
+++ b/views/level.jade
@@ -5,6 +5,7 @@ section.page-level(ng-class='"mode-" + mode'): .page-width
     .row
         .col-6.editor-wrap
                 editor(
+                    workspace,
                     ng-model='code',
                     ng-class='{ completed: completed, disabled: mode == "reading" }',
                     ng-change='validate()',
@@ -14,7 +15,7 @@ section.page-level(ng-class='"mode-" + mode'): .page-width
 
         .col-6.tutorial-wrap
             .display-wrap(v-show='mode === "editing"')
-                display(ng-source='code')
+                display(ng-source='code', workspace)
 
                 .actions
                     a.button(ng-click='openIntro()') Help

--- a/views/main.jade
+++ b/views/main.jade
@@ -11,9 +11,9 @@ section: .page-width
 
     .row
         .col-6
-            editor(ng-model='code', editable='true')
+            editor(ng-model='code', editable='true', workspace)
         .col-6
-            display(ng-source='code')
+            display(ng-source='code', workspace)
 
     .center
         a.button.button-success(href='/level').success Learn

--- a/views/playground.jade
+++ b/views/playground.jade
@@ -5,9 +5,9 @@ section: .page-width
 
     .row
         .col-6
-            editor(ng-model='playground.code', editable='true', auto-select='false')
+            editor(ng-model='playground.code', editable='true', auto-select='false', workspace)
         .col-6
-            display(ng-source='playground.code')
+            display(ng-source='playground.code', workspace)
 
     span(ng-repeat="dialog in exportDialogs"
          ng-controller='export')


### PR DESCRIPTION
This commit catches execution errors of the resulting JS code, maps them
back to the original CoffeeScript code and generates annotations for ace
to mark the line where the error comes from.

To be able to do so, I had to add a new directive that serves as an API
between the display and editor ones. This directive feeds the annotations
to ace on top of the original ones which cover mostly coffeescript syntax.

So we now get both. Yay!

cc @tombettany @tancredi @alex5imon 

Related to: https://github.com/KanoComputing/peldins/issues/1481
