### PR TITLE
Call `stroke` with a consistent argument ordering

### DIFF
--- a/content/docs.json
+++ b/content/docs.json
@@ -215,10 +215,10 @@
             {
                 "call"        : "stroke",
                 "unlockedAt"  : 5,
-                "description" : "Change the color and width of the stroke (border)",
+                "description" : "Change the width and color of the stroke (border)",
                 "args"        : [
-                    [ "size", "number", "(number) The width to use", false ],
-                    [ "color", "string", "A string with the color to use - E.g. 'red', 'blue'..", false ]
+                    [ "color", "string", "A string with the color to use - E.g. 'red', 'blue'..", false ],
+                    [ "size", "number", "(number) The width to use", false ]
                 ],
                 "defaults": [ 10, "purple" ]
             },

--- a/content/examples/abstract.coffee
+++ b/content/examples/abstract.coffee
@@ -17,7 +17,7 @@ move -40, -40
 square 40
 
 # Use a stroke of width 5 and color white
-stroke 5, 'white'
+stroke 'white', 5
 
 # Draw a line to the end of the
 # first rectangle

--- a/lib/challenges/smiley.js
+++ b/lib/challenges/smiley.js
@@ -15,8 +15,8 @@ module.exports = {
             ]
         ],
         [
-            'Choose a thick black stroke - **type** `stroke 20, black`',
-            'stroke 20, black',
+            'Choose a thick black stroke - **type** `stroke black, 20`',
+            'stroke black, 20',
             [
                 [ 'stroke-color', { color: palette.black } ],
                 [ 'stroke-width', { width: 20 } ]

--- a/lib/challenges/summer_camp/day_eleven.js
+++ b/lib/challenges/summer_camp/day_eleven.js
@@ -132,7 +132,7 @@ module.exports = {
         ],
         [
             'Set the `stroke` (the outline of a shape) to size `3` and `black`',
-            'stroke 3, black',
+            'stroke black, 3',
             [
                 [ 'stroke-color', { color: palette.black } ],
                 [ 'stroke-width', { width: 3 } ]

--- a/lib/challenges/summer_camp/day_fifteen.js
+++ b/lib/challenges/summer_camp/day_fifteen.js
@@ -55,8 +55,8 @@ module.exports = {
             ]
         ],
         [
-            'First we will draw the wooden legs supporting it - **type** `stroke 15, brown`',
-            'stroke 15, brown',
+            'First we will draw the wooden legs supporting it - **type** `stroke brown, 15`',
+            'stroke brown, 15',
             [
                 [ 'stroke-color', { color: palette.brown } ],
                 [ 'stroke-width', { width: 15 } ]
@@ -77,8 +77,8 @@ module.exports = {
             ]
         ],
         [
-            'We will draw a target with white and red rings - **type** `stroke 50, white`',
-            'stroke 50, white',
+            'We will draw a target with white and red rings - **type** `stroke white, 50`',
+            'stroke white, 50',
             [
                 [ 'stroke-color', { color: palette.white } ],
                 [ 'stroke-width', { width: 50 } ]
@@ -113,8 +113,8 @@ module.exports = {
             ]
         ],
         [
-            'Our arrowhead will have a thin gray outline - **type** `stroke 1, gray`',
-            'stroke 1, gray',
+            'Our arrowhead will have a thin gray outline - **type** `stroke gray, 1`',
+            'stroke gray, 1',
             [
                 [ 'stroke-color', { color: palette.gray } ],
                 [ 'stroke-width', { width: 1 } ]
@@ -147,8 +147,8 @@ module.exports = {
             ]
         ],
         [
-            'The arrow will be made of a light brown wood - **type** `stroke 20, lightbrown`',
-            'stroke 20, lightbrown',
+            'The arrow will be made of a light brown wood - **type** `stroke lightbrown, 20`',
+            'stroke lightbrown, 20',
             [
                 [ 'stroke-color', { color: palette.lightbrown } ],
                 [ 'stroke-width', { width: 20 } ]
@@ -169,8 +169,8 @@ module.exports = {
             ]
         ],
         [
-            'We are going to draw an arc for the bow so let\'s draw it with a thick piece of dark brown wood - **type** `stroke 40, darkbrown`',
-            'stroke 40, darkbrown',
+            'We are going to draw an arc for the bow so let\'s draw it with a thick piece of dark brown wood - **type** `stroke darkbrown, 40`',
+            'stroke darkbrown, 40',
             [
                 [ 'stroke-color', { color: palette.darkbrown } ],
                 [ 'stroke-width', { width: 40 } ]

--- a/lib/challenges/summer_camp/day_five.js
+++ b/lib/challenges/summer_camp/day_five.js
@@ -29,8 +29,8 @@ module.exports = {
             ]
         ],
         [
-            'Set the stroke for the first circle - **type** `stroke 20, red`',
-            'stroke 20, red',
+            'Set the stroke for the first circle - **type** `stroke red, 20`',
+            'stroke red, 20',
             [
                 [ 'stroke-color', { color: palette.red } ],
                 [ 'stroke-width', { width: 20 } ]
@@ -44,8 +44,8 @@ module.exports = {
             ]
         ],
         [
-            'Set the stroke for the second circle - **type** `stroke 20, yellow`',
-            'stroke 20, yellow',
+            'Set the stroke for the second circle - **type** `stroke yellow, 20`',
+            'stroke yellow, 20',
             [
                 [ 'stroke-color', { color: palette.yellow } ],
                 [ 'stroke-width', { width: 20 } ]
@@ -60,7 +60,7 @@ module.exports = {
         ],
         [
             'Set the `stroke` for the third circle to size `20` and `purple` color',
-            'stroke 20, purple',
+            'stroke purple, 20',
             [
                 [ 'stroke-color', { color: palette.purple } ],
                 [ 'stroke-width', { width: 20 } ]

--- a/lib/challenges/summer_camp/day_fourteen.js
+++ b/lib/challenges/summer_camp/day_fourteen.js
@@ -121,7 +121,7 @@ module.exports = {
         ],
         [
             'Set the outline of the seats with a `stroke` of `10` and `orangered` color.',
-            'stroke 10, orangered',
+            'stroke orangered, 10',
             [
                 [ 'stroke-color', { color: palette.orangered } ],
                 [ 'stroke-width', { 'width': 10 } ]

--- a/lib/challenges/summer_camp/day_nine.js
+++ b/lib/challenges/summer_camp/day_nine.js
@@ -23,7 +23,7 @@ module.exports = {
         ],
         [
             'In a new line, set the outline of your compass with a `stroke` of `20` and `gold` color',
-            'stroke 20, gold',
+            'stroke gold, 20',
             [
                 [ 'stroke-color', { color: palette.gold } ],
                 [ 'stroke-width', { 'width': 20 } ]

--- a/lib/challenges/summer_camp/day_one.js
+++ b/lib/challenges/summer_camp/day_one.js
@@ -80,8 +80,8 @@ module.exports = {
             ]
         ],
         [
-            'Set the stroke to be size 5 and brown (to match the sign). You can do both these things in one command - **type** `stroke 5, brown`',
-            'stroke 5, brown',
+            'Set the stroke to be size 5 and brown (to match the sign). You can do both these things in one command - **type** `stroke brown, 5`',
+            'stroke brown, 5',
             [
                 [ 'stroke-color', { color: palette.brown } ],
                 [ 'stroke-width', { width: 5 } ]

--- a/lib/challenges/summer_camp/day_seventeen.js
+++ b/lib/challenges/summer_camp/day_seventeen.js
@@ -29,8 +29,8 @@ module.exports = {
             ]
         ],
         [
-            'Our waves will be dark blue - **type** `stroke 8, darkblue`',
-            'stroke 8, darkblue',
+            'Our waves will be dark blue - **type** `stroke darkblue, 8`',
+            'stroke darkblue, 8',
             [
                 [ 'stroke-color', { color: palette.darkblue } ],
                 [ 'stroke-width', { width: 8 } ]
@@ -151,8 +151,8 @@ module.exports = {
             { override: true }
         ],
         [
-            'Brilliant! When you press the spacebar, a new set of random numbers is selected and the ripples move!\n\nTo catch some fish we need a brown fishing pole - Exit the loop and **type** `stroke 10, brown`.',
-            'stroke 10, brown',
+            'Brilliant! When you press the spacebar, a new set of random numbers is selected and the ripples move!\n\nTo catch some fish we need a brown fishing pole - Exit the loop and **type** `stroke brown, 10`.',
+            'stroke brown, 10',
             [
                 [ 'stroke-color', { color: palette.brown } ],
                 [ 'stroke-width', { width: 10 } ]
@@ -173,8 +173,8 @@ module.exports = {
             ]
         ],
         [
-            'Next we need some fishing line - **type** `stroke 1, lightgray`',
-            'stroke 1, gray',
+            'Next we need some fishing line - **type** `stroke lightgray, 1`',
+            'stroke lightgray, 1',
             [
                 [ 'stroke-color', { color: palette.lightgray } ],
                 [ 'stroke-width', { width: 1 } ]

--- a/lib/challenges/summer_camp/day_six.js
+++ b/lib/challenges/summer_camp/day_six.js
@@ -78,8 +78,8 @@ module.exports = {
             ]
         ],
         [
-            'Set the stroke for the logs - **type** `stroke 25, brown`',
-            'stroke 25, brown',
+            'Set the stroke for the logs - **type** `stroke brown, 25`',
+            'stroke brown, 25',
             [
                 [ 'stroke-color', { color: palette.brown } ],
                 [ 'stroke-width', { width: 25 } ]
@@ -121,8 +121,8 @@ module.exports = {
             ]
         ],
         [
-            'Set the thickness and color of each line - **type** `stroke 10, \'rgba(255, \' + (i + 50) + \', 0, 0.3)\'`',
-            '    stroke 10, \'rgba(255, \' + (i + 50) + \', 0, 0.3)\'',
+            'Set the thickness and color of each line - **type** `stroke \'rgba(255, \' + (i + 50) + \', 0, 0.3)\', 10`',
+            '    stroke \'rgba(255, \' + (i + 50) + \', 0, 0.3)\', 10',
             function () {
                 var out = [],
                     i = 1;

--- a/lib/challenges/summer_camp/day_ten.js
+++ b/lib/challenges/summer_camp/day_ten.js
@@ -65,7 +65,7 @@ module.exports = {
         ],
         [
             'Set the outline of the lens with a `stroke` of `10` and `black` color',
-            'stroke 10, black',
+            'stroke black, 10',
             [
                 [ 'stroke-color', { color: palette.black } ],
                 [ 'stroke-width', { 'width': 10 } ]

--- a/lib/challenges/summer_camp/day_thirteen.js
+++ b/lib/challenges/summer_camp/day_thirteen.js
@@ -107,7 +107,7 @@ module.exports = {
         ],
         [
             'Set the outline of the soundhole with a `stroke` of `10` and `brown` color.',
-            'stroke 10, brown',
+            'stroke brown, 10',
             [
                 [ 'stroke-color', { color: palette.brown } ],
                 [ 'stroke-width', { 'width': 10 } ]
@@ -136,7 +136,7 @@ module.exports = {
         ],
         [
             'Set the outline of the bridge with a `stroke` of `10` and `red` color.',
-            'stroke 10, red',
+            'stroke red, 10',
             [
                 [ 'stroke-color', { color: palette.red } ],
                 [ 'stroke-width', { 'width': 10 } ]
@@ -158,7 +158,7 @@ module.exports = {
         ],
         [
             'Set the properties of the strings with a `stroke` of `1` and `white` color.',
-            'stroke 1, white',
+            'stroke white, 1',
             [
                 [ 'stroke-color', { color: palette.white } ],
                 [ 'stroke-width', { 'width': 1 } ]


### PR DESCRIPTION
`stroke` can accept its arguments in either order. This is a potential source of confusion, since it’s not the case for functions with a similar signature, like `setTransparency`.

To mitigate that, it seems like a good idea to call `stroke` with a consistent argument order. To be consistent with other functions, I’ve gone for colour first i.e. `stroke [color], [width]`.