### PR TITLE
Summer Camp Sales: Add tracking to sales promo links

### DIFF
--- a/lib/controller/promo-popup.js
+++ b/lib/controller/promo-popup.js
@@ -8,7 +8,7 @@ app.controller('PromoPopupController', function ($scope, $rootScope) {
             'body': 'video',
             'link': {
                 'text': 'Learn more',
-                'url': 'http://www.kano.me/kit'
+                'url': 'http://www.kano.me/kit?utm_source=Summer%20Camp%20Promo&utm_medium=banner&utm_campaign=Summer%20Camp'
             }
         },
         'pi-1': {
@@ -17,7 +17,7 @@ app.controller('PromoPopupController', function ($scope, $rootScope) {
             'body': 'upgrade-kit',
             'link': {
                 'text': 'Learn more',
-                'url': 'http://uk.kano.me/collections/frontpage/products/powerup'
+                'url': 'http://uk.kano.me/collections/frontpage/products/powerup?utm_source=Summer%20Camp%20Promo&utm_medium=banner&utm_campaign=Summer%20Camp'
             }
         },
         'pi-2': {


### PR DESCRIPTION
When targeting users with the Summer Camp promo popup, add tracking to
the links that they are provided.

cc @rcocetta 