### PR TITLE
Fix displaying errors in rewards and rearrange

### DIFF
--- a/lib/challenges/summer_camp/day_nineteen.js
+++ b/lib/challenges/summer_camp/day_nineteen.js
@@ -12,7 +12,7 @@ module.exports = {
     difficulty  : 1,
     startAt     : 0,
     summerCamp  : true,
-    rewards     : ['outfit'],
+    rewards     : {'wallpaper': 1},
     steps       : generate.fromSequence([
         [
             'Set `stroke` to `0`',

--- a/lib/challenges/summer_camp/day_sixteen.js
+++ b/lib/challenges/summer_camp/day_sixteen.js
@@ -12,7 +12,7 @@ module.exports = {
     difficulty  : 2,
     startAt     : 0,
     summerCamp  : true,
-    rewards     : ['wallpaper'],
+    rewards     : {'wallpaper': 1},
     steps       : generate.fromSequence([
         [
             'Begin by setting your stroke to zero with `stroke 0`',

--- a/lib/challenges/summer_camp/day_twenty.js
+++ b/lib/challenges/summer_camp/day_twenty.js
@@ -12,7 +12,7 @@ module.exports = {
     difficulty  : 3,
     startAt     : 0,
     summerCamp  : true,
-    rewards     : ['wallpaper', 'outfit'],
+    rewards     : {'outfit': 1},
     steps       : generate.fromSequence([
     ])
 };

--- a/lib/challenges/summer_camp/day_twentyone.js
+++ b/lib/challenges/summer_camp/day_twentyone.js
@@ -12,8 +12,8 @@ module.exports = {
     difficulty  : 3,
     startAt     : 0,
     summerCamp  : true,
-    rewards     : ['wallpaper', 'outfit'],
+    rewards     : null,
     steps       : generate.fromSequence([
-        
+
     ])
 };


### PR DESCRIPTION
Instead of rewarding with two assets in day 21 these will be split
amongst days 19 and 20