### PR TITLE
Fixes for kit version of make-art

### DIFF
--- a/bin/kano-draw
+++ b/bin/kano-draw
@@ -52,4 +52,12 @@ if len(sys.argv) > 1:
     DRAW = Draw(load_path=sys.argv[1])
 else:
     DRAW = Draw()
-DRAW.run()
+
+# In order to exit from the import server, we send a SIGINT to this process
+# and the signal handler executes as it should. However, GTK decides to throw
+# a keyboard interrupt anyway
+try:
+    DRAW.run()
+except KeyboardInterrupt:
+    # the SIGINT handler has executed here
+    sys.exit(0)

--- a/kano_draw/server.py
+++ b/kano_draw/server.py
@@ -430,5 +430,10 @@ def start(parent_pid=None):
     PARENT_PID = parent_pid
 
     # Run the server
-    server.run(port=8000)
+    try:
+        server.run(port=8000)
+    except EnvironmentError as exc:
+        if exc.errno == 98:
+            logger.error('Another server is running bound at our port')
+            _shutdown()
     time.sleep(2)

--- a/kano_draw/server.py
+++ b/kano_draw/server.py
@@ -37,8 +37,9 @@ ensure_dir(STATIC_ASSET_DIR)
 
 
 def _copy_package_assets():
-    src_dir = _get_package_static_dir()
-    dest_dir = STATIC_ASSET_DIR
+    # Use abs paths for both src and dest for subsequent replacements to work
+    src_dir = os.path.abspath(_get_package_static_dir())
+    dest_dir = os.path.abspath(STATIC_ASSET_DIR)
 
     # First Clear this cache
     for existing_file in os.listdir(dest_dir):
@@ -51,11 +52,19 @@ def _copy_package_assets():
             else:
                 os.remove(cur_file)
 
-    # Now symlink the static assets
-    for dir_entry in os.listdir(src_dir):
-        src_file = os.path.abspath(os.path.join(src_dir, dir_entry))
-        dest_file = os.path.abspath(os.path.join(dest_dir, dir_entry))
-        os.symlink(src_file, dest_file)
+    # Now copy the static assets
+    for root_d, dirs, files in os.walk(src_dir):
+        # Firstly create the dirs
+        dest_root = root_d.replace(src_dir, dest_dir)
+        for dir_n in dirs:
+            new_dir = os.path.join(dest_root, dir_n)
+            os.mkdir(new_dir)
+        # Now deal with the files
+        for file_n in files:
+            src_file = os.path.join(root_d, file_n)
+            new_file = os.path.join(dest_root, file_n)
+            shutil.copy(src_file, new_file)
+    logger.info('Successfully copied over static assets')
 
 
 def _get_package_static_dir():

--- a/kano_draw/server.py
+++ b/kano_draw/server.py
@@ -383,6 +383,16 @@ def _load_level():
 def _shutdown():
     import signal
 
+    try:
+        server_shutdown = request.environ.get('werkzeug.server.shutdown')
+        if server_shutdown is not None:
+            logger.info('Will attempt to shutdown the server')
+            server_shutdown()
+    except Exception as exc:
+        logger.error(
+            'Error while trying to shut down the server: [{}]'.format(exc)
+        )
+
     # Send signal to parent to initiate shutdown
     os.kill(PARENT_PID, signal.SIGINT)
 


### PR DESCRIPTION
* Copy files to home folder instead of symlinking them (makes kano-content integration less error prone)
* Add code that attempts to terminate the python flask server
* Make it so that the binary exits with zero return code when exiting normally