### PR TITLE
Offline API: Allow tracking of lines of code

### DIFF
--- a/kano_draw/server.py
+++ b/kano_draw/server.py
@@ -379,6 +379,18 @@ def _load_level():
     return Response(value, content_type='application/json')
 
 
+@server.route('/lines-of-code', methods=['POST'])
+def _increment_lines_of_code():
+    data = json.loads(request.data)
+    new_lines = data['newLines']
+
+    increment_app_state_variable_with_dialog(
+        APP_NAME, 'lines_of_code', new_lines
+    )
+
+    return ''
+
+
 @server.route('/shutdown', methods=['POST'])
 def _shutdown():
     import signal

--- a/lib/api/offline/local-api.js
+++ b/lib/api/offline/local-api.js
@@ -41,6 +41,12 @@ apiService.add('progress.save', {
     route  : '/progress/:world/:challenge'
 });
 
+apiService.add('linesOfCode.increment', {
+    method : 'post',
+    route  : '/lines-of-code',
+    params : ['newLines']
+});
+
 apiService.add('server.shutdown', {
     method : 'post',
     route  : '/shutdown'

--- a/lib/api/offline/progress.js
+++ b/lib/api/offline/progress.js
@@ -1,7 +1,6 @@
 "use strict";
 var api = require('./local-api'),
-    notify = require('../notify'),
-    onlineProgress;
+    notify = require('../notify');
 
 
 module.exports = function (cfg) {
@@ -63,11 +62,13 @@ module.exports = function (cfg) {
         });
     }
 
-    onlineProgress = require('../online/progress')(cfg);
+    function trackLinesOfCode(increment) {
+        api.linesOfCode.increment({newLines: increment});
+    }
 
     return {
         save             : save,
         load             : load,
-        trackLinesOfCode : onlineProgress.trackLinesOfCode
+        trackLinesOfCode : trackLinesOfCode
     };
 };


### PR DESCRIPTION
The online API was being used to track the lines of code which is prone
to failure when there is no internet connection. Instead utilise the
offline implementation: Kano Profile.

@convolu @rcocetta Could you review?