### PR TITLE
sharing: Limit description to 500 characters

### DIFF
--- a/lib/directive/export-modal.js
+++ b/lib/directive/export-modal.js
@@ -84,6 +84,9 @@ app.directive('exportModal', function ($rootScope, $routeParams) {
                     return showError('Please choose a title');
                 } else if (scope.meta.title.length > 100) {
                     return showError('Title is too long');
+                } else if (scope.meta.description &&
+                           scope.meta.description.length > 500) {
+                    return showError('Description is too long');
                 }
 
                 resetError();


### PR DESCRIPTION
The description field is limited to 500 characters. If exceeded, the sharing will fail with 'Try again later'. This adds a check for that and displays a more appropriate message.

Related to: https://github.com/KanoComputing/peldins/issues/2142

cc @alex5imon @convolu @tombettany 