### PR TITLE
Design touchups

### DIFF
--- a/styles/views/challenges.styl
+++ b/styles/views/challenges.styl
@@ -162,7 +162,7 @@
                 width 100%
                 display block
                 height 240px
-                background-color #3D424C
+                background-color #626770
                 position relative
                 border-radius(3px 3px 3px 3px)
                         

--- a/views/playground.jade
+++ b/views/playground.jade
@@ -1,8 +1,4 @@
 .page-width: .workspace
-    h3.page-title
-        i.icon-game
-        | Playground
-
     .workspace-body: .row
 
         .col-6


### PR DESCRIPTION
1. Change the background of cards to the lighter colour specified in tommy's original spec
2. Remove the "Playground" header in the Playground—it is duplicate UI and takes up valuable real estate on short screens.

<img width="1440" alt="screenshot 2016-01-20 11 20 16" src="https://cloud.githubusercontent.com/assets/4676536/12447566/b3f6b3ec-bf68-11e5-864b-0e25447eee24.png">
