### PR TITLE
Fixed a termination issue that left the UI process running

### DIFF
--- a/bin/kano-draw
+++ b/bin/kano-draw
@@ -41,6 +41,7 @@ UI_PROC = None
 def _kill_subprocess(proc_handle):
     if proc_handle is not None and proc_handle.is_alive():
         proc_handle.terminate()
+        os.kill(proc_handle.pid, signal.SIGKILL)
 
 
 def _kill_lingering_processes():

--- a/kano_draw/server.py
+++ b/kano_draw/server.py
@@ -368,6 +368,11 @@ def _increment_lines_of_code():
 
 @server.route('/shutdown', methods=['POST'])
 def _shutdown():
+    '''
+    Obtain the entry point to stop the http server.
+    We do not kill the parent launcher proces (kano-draw)
+    because he is keeping an eye on both the http and ui processes.
+    '''
     import signal
 
     try:
@@ -379,9 +384,6 @@ def _shutdown():
         logger.error(
             'Error while trying to shut down the server: [{}]'.format(exc)
         )
-
-    # Send signal to parent to initiate shutdown
-    os.kill(PARENT_PID, signal.SIGINT)
 
 
 @server.route('/browsemore', methods=['POST'])


### PR DESCRIPTION
 * When integrating kano-draw from QML, the launcher process would morph,
   and the UI frontend keep running
 * Fixed by not killing the parent from the http process
 * Forcibly killing the UI process from the launcher more agressively (SIGKILL)

cc @tombettany @convolu what do you think?
