### PR TITLE
Update play-audio version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "moment": "^2.10.6",
     "nib": "~1.0.x",
     "partialify": "^3.1.1",
-    "play-audio": "^0.1.0",
+    "play-audio": "^2.0.0",
     "throttle-debounce": "^0.1.1",
     "tiny-lr": "0.0.9"
   },


### PR DESCRIPTION
Something happened in the play-audio npm repo and it broke the npm install of make-art. Updating the version fixes it