### PR TITLE
Some fixes to restore building on the kit.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -13,6 +13,6 @@ kano-draw (2.2.0-1) unstable; urgency=low
 
 kano-draw (1.0-1) UNRELEASED; urgency=low
 
-  * Initial release. (Closes: #XXXXXX)
+  * Initial release.
 
- -- Alex <alex@Kano>  Wed, 16 Apr 2014 17:40:58 +0100
+ -- Alex <alex@kano.me>  Wed, 16 Apr 2014 17:40:58 +0100

--- a/debian/control
+++ b/debian/control
@@ -11,3 +11,5 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, kano-toolset (>= 2.3.0-5),
     kano-profile (>= 1.3-2), python-flask
 Suggests: kano-video-files (>= 1.2-1)
 Description: Draw with code
+    An app for learning programming using a basic CoffeeScript drawing API
+

--- a/debian/copyright
+++ b/debian/copyright
@@ -4,4 +4,4 @@ Source: https://github.com/KanoComputing/kano-draw
 
 Files: *
 Copyright: 2014,2015 Kano Computing Ltd.
-License: GPL-2+
+License: GPL-2+ On Debian systems the complete text of the GPL is in /usr/share/common-licenses/GPL-2

--- a/debian/kano-draw.lintian-overrides
+++ b/debian/kano-draw.lintian-overrides
@@ -1,0 +1,2 @@
+kano-draw binary: privacy-breach-facebook
+kano-draw binary: privacy-breach-twitter

--- a/debian/rules
+++ b/debian/rules
@@ -9,5 +9,6 @@ override_dh_auto_build:
 	apt-get install --yes nodejs
 	npm install
 	NODE_ENV=production OFFLINE=true npm run build
+	dh_lintian
 
 override_dh_auto_install override_dh_auto_test:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -249,7 +249,7 @@ gulp.task('copy-challenges', function (next) {
 });
 
 gulp.task('compress', function () {
-    gulp.src('www/js/index.js', { base: 'www' })
+    return gulp.src('www/js/index.js', { base: 'www' })
         .pipe(ngAnnotate())
         .pipe(uglify())
         .pipe(gulp.dest('www'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -248,8 +248,8 @@ gulp.task('copy-challenges', function (next) {
 
 });
 
-gulp.task('compress', () => {
-    return gulp.src('www/js/index.js', { base: 'www' })
+gulp.task('compress', function () {
+    gulp.src('www/js/index.js', { base: 'www' })
         .pipe(ngAnnotate())
         .pipe(uglify())
         .pipe(gulp.dest('www'));


### PR DESCRIPTION
- Some problem with the gulpfile (Not entirely sure of this, please review carefully!)
- Fix a bunch of complaints from  lintian:
  - Invalid email address in changelog
  - no 'extended description'
  - missing path for the licence file
  - privacy warnings
    @arifshanji @paulvarache 
