### PR TITLE
Fix navigation issues

### DIFF
--- a/styles/elements/hero-header.styl
+++ b/styles/elements/hero-header.styl
@@ -1,4 +1,7 @@
 .hero-header
+    -webkit-font-smoothing antialiased
+    -moz-osx-font-smoothing grayscale
+
     .hero-image
         height 35vw
         max-height 340px

--- a/views/partial/kano-nav.jade
+++ b/views/partial/kano-nav.jade
@@ -3,8 +3,8 @@ link(rel='import' href='/components/kano-primary-links/kano-primary-links.html')
 link(rel='import' href='/components/kano-secondary-links/kano-secondary-links.html')
 
 .kano-navigation(ng-show='selectedWorld && selectedWorld.display_menu')
-    kano-nav(assets-path='/assets/kano-nav/')
-        kano-primary-links(slot='primary')
+    kano-nav(assets-path='/assets/kano-nav/' site-root='https://world.kano.me')
+        kano-primary-links(current-site='{{window.location.origin}}' slot='primary')
         ul.nav.nav-secondary(slot='secondary')
 
             li: a(href='/challenges', ng-class='{ active: basePath === "challenge" || basePath === "challenges" }')

--- a/views/partial/kano-nav.jade
+++ b/views/partial/kano-nav.jade
@@ -3,7 +3,7 @@ link(rel='import' href='/components/kano-primary-links/kano-primary-links.html')
 link(rel='import' href='/components/kano-secondary-links/kano-secondary-links.html')
 
 .kano-navigation(ng-show='selectedWorld && selectedWorld.display_menu')
-    kano-nav(assets-path='/assets/kano-nav/' site-root='https://world.kano.me')
+    kano-nav(assets-path='/assets/kano-nav/' site-root='{{cfg.WORLD_URL}}')
         kano-primary-links(current-site='{{window.location.origin}}' slot='primary')
         ul.nav.nav-secondary(slot='secondary')
 


### PR DESCRIPTION
* Adds site-root to Kano Nav to allow linking of logo to Kano World
* Adds current site to Kano Primary Links to fix broken links
* Updates font smoothing to remove inconsistent bold

Trello cards:
https://trello.com/c/Iumqbokp/803-3-add-top-level-navigation-bar-to-http-art-kano-me-challenges-pixelhack
https://trello.com/c/4qpNOhRA/831-2-update-pixel-hack-to-push-educator-pack-further-up