### PR TITLE
Fire page tracking only if the route is valid, with content – ie. not an internal redirection

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -253,8 +253,11 @@ app.run(function ($rootScope, $window) {
     // Update basePath on route change
     $rootScope.$on('$routeChangeSuccess', function (e, route) {
         var path = route.$$route ? route.$$route.originalPath : null;
+        var redirection = route.$$route ? route.$$route.redirectTo : null;
         $rootScope.basePath = path ? path.split('/')[1] : '';
-        analytics.page(path);
+        if (path && !redirection) {
+            analytics.page(path);
+        }
     });
 });
 


### PR DESCRIPTION
Aims to cut down on the virtualPageView event duplication, and fix tracking issues.