### PR TITLE
Remove trackEvent listener

### DIFF
--- a/lib/controller/auth-form.js
+++ b/lib/controller/auth-form.js
@@ -27,7 +27,6 @@ app.controller('AuthController', ['$scope', '$rootScope', '$element', 'API', 'AU
     };
 
     $scope.onSignupSuccess = function (ev) {
-        var user = ev.details.user;
         tracking.dispatchTrackingEvent('signedUpToKanoWorld');
     };
 

--- a/lib/core/tracking.js
+++ b/lib/core/tracking.js
@@ -106,10 +106,6 @@ function dispatchVirtualPageView() {
  * @return void
  */
 function init () {
-  window.addEventListener('trackEvent', function(e) {
-      dispatchTrackingEvent(e.detail);
-  });
-
   checkUserType();
   checkVisitType();
   checkAccount();


### PR DESCRIPTION
The only event that seems to have been firing is the sdk, which fires a signedInToKanoWorld event on successful sign in. This was causing duplication with the in-app event. Since all other tracking is handled by the app, and no other events are triggering this, it seems best to remove the listener to prevent any other rogue events firing.

Trello card: https://trello.com/c/rjMJSqys/1621-2-implement-kano-code-tracking-on-make-art