### PR TITLE
Standardise avatars used with other properties

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -109,7 +109,6 @@ app.run(function ($rootScope, $window) {
                     $rootScope.user.profile = user.profile;
                 }
                 $rootScope.$broadcast('user-profile-loaded');
-
             });
         }
     }

--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -29,6 +29,7 @@ module.exports = {
                 'hideShares': true
             }
         },
+        DEFAULT_AVATAR  : 'https://s3-eu-west-1.amazonaws.com/world.kano.me/users/avatars/563890fec4d6960800c721f7/avatar-circle.png',
         languageSynonyms: langSynonyms
     },
     "development": {
@@ -37,12 +38,12 @@ module.exports = {
         API_URL         : 'http://localhost:1234',
         UNKNOWN_USER    : 'tanc'
     },
-    "staging": {        
+    "staging": {
         FACEBOOK_APP_ID : '832712683515218',
         API_URL     : 'https://api-staging.kano.me',
         WORLD_URL   : 'https://world-staging.kano.me',
         UNKNOWN_USER    : 'tanc'},
-    "production": {        
+    "production": {
         FACEBOOK_APP_ID : '832712683515218',
         API_URL     : 'https://api.kano.me',
         WORLD_URL   : 'http://world.kano.me',

--- a/views/partial/header.jade
+++ b/views/partial/header.jade
@@ -1,6 +1,6 @@
 include kano-nav
 
-header: .main-navigation.page-width(ng-hide='selectedWorld && selectedWorld.display_menu')
+header: .main-navigation.page-width(ng-if='offline || !selectedWorld || !selectedWorld.display_menu')
 
     a.logo(href='/')
     //- if !offline
@@ -28,7 +28,7 @@ header: .main-navigation.page-width(ng-hide='selectedWorld && selectedWorld.disp
 
         li(ng-if='!offline && loggedIn')
             a.user-display(ng-href='http://world.kano.me/users/{{ user.username }}', target='_blank')
-                .avatar: img(ng-src='http://avatar.kano.me/username/{{ user.username }}.png')
+                .avatar: img(ng-src='{{ user.avatar.urls.circle || cfg.DEFAULT_AVATAR }}')
                 | {{ user.username }}
 
         li(ng-if='!offline && loggedIn'): a(href='#', ng-click='logout()')

--- a/views/partial/kano-nav.jade
+++ b/views/partial/kano-nav.jade
@@ -1,4 +1,4 @@
-.kano-navigation(ng-show='selectedWorld && selectedWorld.display_menu')
+.kano-navigation(ng-show='!offline && selectedWorld && selectedWorld.display_menu')
     kano-nav(assets-path='/assets/kano-nav/' site-root='{{cfg.WORLD_URL}}')
         kano-primary-links(current-site='{{window.location.origin}}' slot='primary')
         ul.nav.nav-secondary(slot='secondary')
@@ -18,7 +18,7 @@
 
             li(ng-if='!offline && loggedIn')
                 a.user-display(ng-href='http://world.kano.me/users/{{ user.username }}', target='_blank')
-                    .avatar: img(ng-src='http://avatar.kano.me/username/{{ user.username }}.png')
+                    .avatar: img(ng-src='{{ user.avatar.urls.circle || cfg.DEFAULT_AVATAR }}')
                     .username
                         | {{ user.username }}
 


### PR DESCRIPTION
* Loads avatars from user object, or falls back to default avatar, as with all other properties
* Ensures that there are no discrepancies between development/staging/production
* Also ensures that the `kano-nav` won't be displayed on the kit

Trello card: https://trello.com/c/pk2YZCef/1716-make-art-user-icon-broken