### PR TITLE
Force user update after signup, and call loadUserProfile & loadProgress from $rootScope

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -98,7 +98,7 @@ app.run(function ($rootScope, $window) {
      * Loads the user profile inside the $rootScope
      * @param  {string} userId the UserId
      */
-    function loadUserProfile(userId) {
+    $rootScope.loadUserProfile = function (userId) {
         if (!cfg.OFFLINE) {
             api.profile.getProfile({userId: userId}).then(function (res) {
                 var user = (res && res.body) ? res.body.user : undefined;
@@ -106,6 +106,7 @@ app.run(function ($rootScope, $window) {
                     $rootScope.user.profile = user.profile;
                 }
                 $rootScope.$broadcast('user-profile-loaded');
+                $rootScope.$apply();
             });
         }
     }
@@ -118,15 +119,16 @@ app.run(function ($rootScope, $window) {
         $rootScope.loggedIn = auth.getState();
         $rootScope.user = user;
         if (user) {
-            loadUserProfile(user.id);
-            loadProgress();
+            $rootScope.loadUserProfile(user.id);
+            $rootScope.loadProgress();
+            $rootScope.$apply();
         }
     };
 
     /**
      * Loads the user progress into the $rootScope
      */
-    function loadProgress () {
+    $rootScope.loadProgress = function () {
         // Load progress
         api.progress.load(function (groups) {
             if (groups && Object.keys(groups).length) {
@@ -201,7 +203,7 @@ app.run(function ($rootScope, $window) {
         if (user) {
             if (!localStorage.uuid) {
                 localStorage.uuid = user.id;
-                loadUserProfile(user.id);
+                $rootScope.loadUserProfile(user.id);
             } else {
                 if (localStorage.uuid !== user.id) {
                     localStorage.uuid = user.id;

--- a/lib/controller/auth-form.js
+++ b/lib/controller/auth-form.js
@@ -28,6 +28,9 @@ app.controller('AuthController', ['$scope', '$rootScope', '$element', 'API', 'AU
 
     $scope.onSignupSuccess = function (ev) {
         tracking.dispatchTrackingEvent('signedUpToKanoWorld');
+        $rootScope.$apply(function () {
+            $rootScope.updateUser();
+        });
     };
 
     $scope.close = function () {


### PR DESCRIPTION
Enables user object to properly update on auth changes and should fix the bugs with logging in, logging out and signing up.

Trello cards:
https://trello.com/c/XoyTc0gf/1776-make-art-logging-in-on-make-art-does-nothing-it-does-not-log-you-in
https://trello.com/c/gQDZZX1H/1727-make-art-pixel-hack-sign-up-button-missing-on-header-menu