### PR TITLE
i18n error messages

### DIFF
--- a/locales/en/directive.json
+++ b/locales/en/directive.json
@@ -22,5 +22,8 @@
     "download_teachers_guide": "Download teacher's guide",
     "guide": "Guide",
     "recipients_email_address": "Recipient\\'s email address",
-    "your_message": "Your message"
+    "your_message": "Your message",
+    "error": "{{ error.type | upperfirst }} Error",
+    "error_line": "on line {{ error.row + 1 || 0  }}",
+    "error_text": "{{ error.text || 0 }}"
 }

--- a/locales/es-AR/directive.json
+++ b/locales/es-AR/directive.json
@@ -20,5 +20,8 @@
     "reset": "Reiniciar", 
     "click_plus_to_add_a_shape_2": "para agregar una figura", 
     "autocomplete": "Autocompletar", 
-    "guide": "Guía"
+    "guide": "Guía",
+    "error": "Error de Sintaxis",
+    "error_line": "en la línea {{ error.row + 1 || 0  }}",
+    "error_text": ""
 }

--- a/locales/ja/directive.json
+++ b/locales/ja/directive.json
@@ -22,5 +22,8 @@
     "download_teachers_guide": "教師用のガイドをダウンロード",
     "guide": "ガイド",
     "recipients_email_address": "宛先のメールアドレス",
-    "your_message": "メッセージ"
+    "your_message": "メッセージ",
+    "error": "{{ error.type | upperfirst }} Error",
+    "error_line": "on line {{ error.row + 1 || 0  }}",
+    "error_text": "{{ error.text || 0 }}"
 }

--- a/views/directive/display.jade
+++ b/views/directive/display.jade
@@ -12,10 +12,10 @@
         .error-display(ng-if='error', ng-class='"error-" + error.type')
 
             h3
-                | {{ error.type | upperfirst }} Error 
-                span(ng-if='error.row !== null') on line {{ error.row + 1 || 0  }}
+                | ${{ directive.error }}$ 
+                span(ng-if='error.row !== null') ${{ directive.error_line }}$
 
-            p {{ error.text || 0 }}
+            p ${{ directive.error_text }}$
 
     .actions
         


### PR DESCRIPTION
note: detailed syntax error messages removed in es_AR! this is because the error message text is coming from deep within the ace editor library and fully translating them is a challenge for another day.