### PR TITLE
RPi: Serve homepage for /challenge/.* routes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,8 +2,9 @@ kano-draw (3.14.0-0) unstable; urgency=low
 
   * Applied changes from v3.9.2 es_AR backports to latest
   * Added Loading animation splash window
+  * Fixed returning from shares when launched through challenge pack pages
 
- -- Team Kano <dev@kano.me>  Mon, 16 Oct 2017 15:12:00 +0100
+ -- Team Kano <dev@kano.me>  Mon, 4 Dec 2017 10:50:00 +0100
 
 kano-draw (3.11.0-1) unstable; urgency=low
 

--- a/kano_draw/server.py
+++ b/kano_draw/server.py
@@ -1,6 +1,6 @@
 # server.py
 #
-# Copyright (C) 2014-2015 Kano Computing Ltd.
+# Copyright (C) 2014-2015, 2017 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
 
@@ -99,6 +99,7 @@ server_logger.setLevel(logging.ERROR)
 # Return the homepage for pages routed through Angular
 @server.route('/localLoad/<path:path>')
 @server.route('/challenges')
+@server.route('/challenges/<path:path>')
 @server.route('/playground')
 def root(path=None):
     return server.send_static_file('index.html')


### PR DESCRIPTION
If the user launches a share from one of the challenge pack pages on
Kano OS and then clicks the "Back" button they were presented with a 404
page because Angular handles the page redirection instead of the server.
Resolve this by returning the homepage (main Angular app) from the
server when all routes of the form `/challenge/.*` are requested.