### PR TITLE
Disabled calls to kano.profiling

### DIFF
--- a/bin/kano-draw
+++ b/bin/kano-draw
@@ -2,15 +2,15 @@
 
 # kano-draw
 #
-# Copyright (C) 2014-2015 Kano Computing Ltd.
+# Copyright (C) 2014-2018 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
 # The Draw App implementation
 #
 
 # Before loading anything else, declare a profiling timepoint
-from kano.profiling import declare_timepoint
-declare_timepoint("load", True)
+# from kano.profiling import declare_timepoint
+# declare_timepoint("load", True)
 
 import os
 import sys

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
 kano-draw (3.15.0-0) unstable; urgency=low
 
   * Small challenge copy fixes
+  * Disabled kano.profiling calls
 
- -- Team Kano <dev@kano.me>  Thu, 21 Dec 2017 10:33:00 +0100
+ -- Team Kano <dev@kano.me>  Wed, 31 Jan 2018 15:37:00 +0100
 
 kano-draw (3.14.0-0) unstable; urgency=low
 


### PR DESCRIPTION
The purpose here is to avoid running profiling code in production.
This should perhaps only be enabled in a special env.

Related to: https://github.com/KanoComputing/kano-toolset/pull/278