### PR TITLE
[OS-93] Browser: Disable the inspector

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ kano-draw (4.2.0-0) unstable; urgency=low
 
   * Minor spelling fixes in challenges
   * Added more logging at application termination time
+  * Disable the inspector to prevent accidental triggering
 
  -- Team Kano <dev@kano.me>  Thu, 16 Oct 2018 18:48:19 +0100
 

--- a/kano_draw/draw.py
+++ b/kano_draw/draw.py
@@ -25,9 +25,6 @@ class Draw(WebApp):
         self._decoration = False
         self._maximized = True
 
-        # Enable developer extras to allow error reporting to work
-        self._inspector = True
-
 
 # We require this function for starting the UI as a subprocess
 def start_draw(load_path='', make=False, play=False):


### PR DESCRIPTION
The inspector was disabled in 7566ce4 because it was preventing errors
created by 757edca from being correctly displayed to the user. This
unfortunately has the side-effect that it is possible to launch the
inspector with no way of being able to close it. Since the initial
commit, the underlying webkit has been updated and seems to not suffer
from the same problems so disable the inspector to prevent this.