### PR TITLE
[OS-983] CK Sharing: Switch to use the unified sharing flow

### DIFF
--- a/lib/api/notify.js
+++ b/lib/api/notify.js
@@ -55,6 +55,11 @@ function success() {
     notify('Successful', 'success');
 }
 
+
+function inform(msg) {
+    notify(msg, 'inform');
+}
+
 /*
  * Wraps item in array if it's not an array
  *
@@ -73,5 +78,6 @@ function ensureArray(arr) {
 
 module.exports = {
     success : success,
-    failure : failure
+    failure : failure,
+    inform  : inform
 };

--- a/lib/api/offline/challenge-io.js
+++ b/lib/api/offline/challenge-io.js
@@ -33,6 +33,21 @@ module.exports = {
             }
         }, notify.failure);
     },
+    unifiedShare: function(code, image, cb) {
+        notify.inform('Opening sharing window...');
+        api.challenge.unifiedShare({
+            code: code,
+            image: image
+        }).then(function(res) {
+            if (res.body === '') {
+                notify.success();
+                cb(res);
+            } else {
+                notify.failure(res);
+                cb(res);
+            }
+        });
+    },
     load: function (cb) {
         api.challenge.load()
         .then(function (res) {

--- a/lib/api/offline/local-api.js
+++ b/lib/api/offline/local-api.js
@@ -25,6 +25,12 @@ apiService.add('challenge.share', {
     params : ['filename', 'description', 'code', 'image']
 });
 
+apiService.add('challenge.unifiedShare', {
+    method : 'post',
+    route  : '/challenge/unifiedShare',
+    params : ['code', 'image']
+});
+
 apiService.add('challenge.localLoad', {
     method : 'get',
     route  : '/challenge/local/:path',

--- a/lib/directive/export-modal.js
+++ b/lib/directive/export-modal.js
@@ -159,7 +159,7 @@ app.directive('exportModal', function ($rootScope, $routeParams) {
              * @return {String}
              */
             function getImageURL() {
-                return scope.canvas.toDataURL('image/png');
+                return scope.display.canvas.toDataURL('image/png');
             }
 
             /*
@@ -172,7 +172,16 @@ app.directive('exportModal', function ($rootScope, $routeParams) {
                 // Open or close on parent display modal state change
                 scope.display.$watch('openModal', function (modalId) {
                     if (modalId === scope.action && !scope.open) {
-                        open();
+                        var config = $rootScope.cfg;
+                        if (config.OFFLINE) {
+                            var code = scope.display.source;
+                            var image = getImageURL();
+
+                            api.challengeIO.unifiedShare(code, image);
+                            scope.close();
+                        } else {
+                            open();
+                        }
                     } else if (scope.open) {
                         scope.close();
                     }

--- a/styles/elements/notify.styl
+++ b/styles/elements/notify.styl
@@ -17,3 +17,6 @@ width = 250px
 
     &.fail
         background color-red
+
+    &.inform
+        background color-blue


### PR DESCRIPTION
Outsource the sharing to the unified system sharing flow rather than
handling it directly from within the app so that COPPA compliance can be
applied across the system without having to implement everywhere.

Builds on the snapshot from v4.2.1 rather than building on `master` to simplify deployment. Eventually, this change should be cherry picked (and slightly modified) for running on the `master` code.