### PR TITLE
[PC-245] Fix: Catch unhanded exceptions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,11 @@ import './directive/social.js';
 import { app } from './app.js';
 
 
+window.onerror = function(message, file, line, col, error) {
+    console.error("Error occurred: " + error.message);
+    return true;
+};
+
 window.MakeArt = {
     app,
     bootstrap(host) {


### PR DESCRIPTION
This bug `Unable to get property 'ChildNodes' of undefined or null reference` is specific for windows applications and browsers, and will happen whenever the user'action will select multiple lines of code outside of the  available windows (eg. in playground), this will cause the app to crash  because it won't store/save old lines of code (html). With window.onerror we will just print the error and preserve the app's status.