### PR TITLE
fix: cursor position

### DIFF
--- a/lib/directive/display.js
+++ b/lib/directive/display.js
@@ -122,7 +122,7 @@ app.directive('display', ['$window', '$rootScope', '_config', function ($window,
                         // Reset error, evaluate code and catch new potentia;errors
                         scope.error = null;
                         err = language.run(scope.source, settings);
-                        scope.cursorPosition = language.cursorPosition || scope.getCenter();
+                        scope.cursorPosition = language.cursorPosition() || scope.getCenter();
                         scope.displayCoordsPos();
 
                         if (err) {

--- a/lib/language/index.js
+++ b/lib/language/index.js
@@ -218,7 +218,6 @@ export default {
     run   : run,
     strip : strip,
     checkValidity: checkValidity,
-    evalInContext: evalInContext
+    evalInContext: evalInContext,
+    cursorPosition: () => session.pos,
 };
-
-export const cursorPosition = session.pos;


### PR DESCRIPTION
With es6 modules, the position object was copied instead of keeping a reference. When moving with `moveTo`, the object is replaced. This uses a function. The value is read when the position is updated