### PR TITLE
[OS-1064] Create Jenkins build job for Kano OS

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,12 +1,10 @@
 #!/usr/bin/make -f
-
 %:
 	dh $@
-
 override_dh_auto_build:
 	# NodeJS and npm
 	# FIXME - these must be fix for internationalization languages 
-	# cd po && ./lang-extract-doc-stringsgit
+	# cd po && ./lang-extract-doc-strings
 	# cd po && ./lang-extract-strings
 	# Add NPM repository
 	curl -sL https://deb.nodesource.com/setup_10.x | bash -
@@ -17,15 +15,12 @@ override_dh_auto_build:
 	apt-get update
 	# install Node and yarn
 	apt-get install --yes nodejs yarn
-	# login npm and npx
-	npm i -g npx
-	npm i npm-login-cmd
-	npx npm-login-cmd
+	#login in npm
+	echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 	# Actually build
 	yarn
 	yarn install
 	OFFLINE=true NODE_ENV=production yarn build --env=production
 	OFFLINE=true NODE_ENV=production yarn build:web --env=production
-
 
 override_dh_auto_install override_dh_auto_test:

--- a/debian/rules
+++ b/debian/rules
@@ -16,6 +16,7 @@ override_dh_auto_build:
 	# install Node and yarn
 	apt-get install --yes nodejs yarn
 	#login in npm
+	mkdir -p ~/
 	echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 	# Actually build
 	yarn

--- a/jenkins/kano-os.groovy
+++ b/jenkins/kano-os.groovy
@@ -6,7 +6,7 @@ node('os') {
      stage('build') {
          dr {
              withCredentials([string(credentialsId: 'npm-read-only', variable: 'NPM_TOKEN')]) {
-                 sh script: "set -e; dr build kano-draw -b OS-1064/jenkins-built-process-for-KanoOS"
+                 sh script: "dr build kano-draw -b ${env.BRANCH_NAME}"
                  
              }
          }

--- a/jenkins/kano-os.groovy
+++ b/jenkins/kano-os.groovy
@@ -1,0 +1,16 @@
+#!/usr/bin/env groovy
+
+@Library('kanolib') _
+
+node('os') {
+     stage('build') {
+         dr {
+             withCredentials([string(credentialsId: 'npm-read-only', variable: 'NPM_TOKEN')]) {
+                 sh script: "set -e; dr build kano-draw -b OS-1064/jenkins-built-process-for-KanoOS"
+                 
+             }
+         }
+         
+     }
+    
+}


### PR DESCRIPTION
We Integrate Make Art with our Jenkins build process and create a build job specifically for Kano OS.
We add an npmrc file and jenkins config for automatic build for KanoOS on push passing the  password from Jenkins in the npmrc file. We make sure we have a user home directory to place our npmrc file.
