### PR TITLE
fix gutter from hiding text and cursor

### DIFF
--- a/styles/editor/theme.styl
+++ b/styles/editor/theme.styl
@@ -1,12 +1,3 @@
-// HACK: Force the ACE gutter size to a fixed width
-gutter-size(width)
-
-    .ace_scroller
-        left 30px !important
-
-    .ace_gutter-layer
-        width 30px !important
-
 editor-tag(color = color-primary, color-text = #fff)
     border-radius()
     background color


### PR DESCRIPTION
when project length is >= 100 lines, the cursor in column position 0 will be hidden by the gutter being too wide and hiding the left-most part of the code editor. removing these lines in production seem to fix things, sadly as this is no longer an open-source project i can't verify this is the proper fix by building it myself.